### PR TITLE
Adjust the routing to avoid mounting to root

### DIFF
--- a/app.py
+++ b/app.py
@@ -26,8 +26,8 @@ def get_status():
 # A bit odd, but the only way I've been able to get prefixing of the Dash app
 # to work is by allowing the Dash/Flask app to prefix itself, then mounting
 # it to root
-dash_app = create_dash_app(routes_pathname_prefix="/dash/")
-app.mount("/", WSGIMiddleware(dash_app.server))
+dash_app = create_dash_app(requests_pathname_prefix="/dash/")
+app.mount("/dash", WSGIMiddleware(dash_app.server))
 
 
 if __name__ == "__main__":

--- a/dashapp.py
+++ b/dashapp.py
@@ -8,7 +8,7 @@ import pandas as pd
 import os
 
 
-def create_dash_app(routes_pathname_prefix: str = None) -> dash.Dash:
+def create_dash_app(requests_pathname_prefix: str = None) -> dash.Dash:
     """
     Sample Dash application from Plotly: https://github.com/plotly/dash-hello-world/blob/master/app.py
     """
@@ -17,7 +17,7 @@ def create_dash_app(routes_pathname_prefix: str = None) -> dash.Dash:
 
     df = pd.read_csv('https://raw.githubusercontent.com/plotly/datasets/master/hello-world-stock.csv')
 
-    app = dash.Dash(__name__, server=server, routes_pathname_prefix=routes_pathname_prefix)
+    app = dash.Dash(__name__, server=server, requests_pathname_prefix=requests_pathname_prefix)
 
     app.scripts.config.serve_locally = False
     dcc._js_dist[0]['external_url'] = 'https://cdn.plot.ly/plotly-basic-latest.min.js'


### PR DESCRIPTION
I found a way to get the Dash app to be mounted on "/dash" instead of mounting to the root. Hopefully, it adds some clarity as to what the mount is doing.